### PR TITLE
Goss tests for accounts-www

### DIFF
--- a/chart/tests/carto.yaml
+++ b/chart/tests/carto.yaml
@@ -1,0 +1,57 @@
+{
+  "phases": {
+    "package": {
+      "context": {
+        "resources": {
+          "url": "https://github.com/CartoDB/carto3-helm/archive/refs/tags/v0.0.4.tar.gz",
+          "path": "/chart"
+        }
+      },
+      "actions": [
+        {
+          "action_id": "linter-packaging",
+          "params": {
+            "kind": "HELM"
+          }
+        }
+      ]
+    },
+    "verify": {
+      "context": {
+        "resources": {
+          "url": "https://s3.amazonaws.com/bitnami-autobuild-ondemand/temporary/s3temp-bitnami-20220113161539-50692/carto-0.0.4.tgz?AWSAccessKeyId=AKIAJUJS62Y5YSCL4CIA&Expires=1642349739&Signature=d5xdKVbZ1zlkVpxujkErHPyZO2U=",
+          "path": "/tests"
+        },
+        "application": {
+          "kind": "HELM",
+          "details": {
+            "name": "carto",
+            "version": "0.0.4",
+            "repository": {
+              "url": "https://s3.amazonaws.com/bitnami-autobuild-ondemand/temporary/s3temp-bitnami-20220113161637-50838/carto3-helm.tar.gz?AWSAccessKeyId=AKIAJUJS62Y5YSCL4CIA&Expires=1642349797&Signature=NEvTRkDMWfWi/dT5j%2BLnca0gzZc="
+            }
+          },
+          "values": "b25QcmVtRG9tYWluOiAidGVzdC5jYXJ0by5sb2NhbCIKCmltcG9ydFdvcmtlcjoKICBjb21tYW5kOgogICAgLSBzaAogICAgLSAtYwogICAgLSBzbGVlcCBpbmZpbml0eQoKd29ya3NwYWNlU3Vic2NyaWJlcjoKICBjb21tYW5kOgogICAgLSBzaAogICAgLSAtYwogICAgLSBzbGVlcCBpbmZpbml0eQo="
+        },
+        "target_platform": {
+          "target_platform_id": "91d398a2-25c4-4cda-8732-75a3cfc179a1"
+        }
+      },
+      "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "goss/goss-accounts-www"
+            },
+            "config": {
+              "remote": {
+                "workload": "deploy-accounts-www"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/chart/tests/carto.yaml
+++ b/chart/tests/carto.yaml
@@ -22,17 +22,8 @@
     "verify": {
       "context": {
         "resources": {
-          "url": "https://github.com/CartoDB/carto3-helm/releases/download/v0.0.4/carto3-helm.tar.gz",
+          "url": "https://github.com/CartoDB/carto3-helm/archive/refs/tags/v0.0.4.tar.gz",
           "path": "chart/tests"
-        },
-        "application": {
-          "kind": "HELM",
-          "details": {
-            "name": "carto",
-            "package": {
-              "url": "https://github.com/CartoDB/carto3-helm/releases/download/v0.0.4/carto-0.0.4.tgz"
-            }
-          },
         },
         "runtime_parameters": "b25QcmVtRG9tYWluOiAidGVzdC5jYXJ0by5sb2NhbCIKCmltcG9ydFdvcmtlcjoKICBjb21tYW5kOgogICAgLSBzaAogICAgLSAtYwogICAgLSBzbGVlcCBpbmZpbml0eQoKd29ya3NwYWNlU3Vic2NyaWJlcjoKICBjb21tYW5kOgogICAgLSBzaAogICAgLSAtYwogICAgLSBzbGVlcCBpbmZpbml0eQo=",
         "target_platform": {

--- a/chart/tests/carto.yaml
+++ b/chart/tests/carto.yaml
@@ -19,16 +19,15 @@
     "verify": {
       "context": {
         "resources": {
-          "url": "https://s3.amazonaws.com/bitnami-autobuild-ondemand/temporary/s3temp-bitnami-20220113161539-50692/carto-0.0.4.tgz?AWSAccessKeyId=AKIAJUJS62Y5YSCL4CIA&Expires=1642349739&Signature=d5xdKVbZ1zlkVpxujkErHPyZO2U=",
-          "path": "/tests"
+          "url": "https://github.com/CartoDB/carto3-helm/releases/download/v0.0.4/carto3-helm.tar.gz",
+          "path": "chart/tests"
         },
         "application": {
           "kind": "HELM",
           "details": {
             "name": "carto",
-            "version": "0.0.4",
-            "repository": {
-              "url": "https://s3.amazonaws.com/bitnami-autobuild-ondemand/temporary/s3temp-bitnami-20220113161637-50838/carto3-helm.tar.gz?AWSAccessKeyId=AKIAJUJS62Y5YSCL4CIA&Expires=1642349797&Signature=NEvTRkDMWfWi/dT5j%2BLnca0gzZc="
+            "package": {
+              "url": "https://github.com/CartoDB/carto3-helm/releases/download/v0.0.4/carto-0.0.4.tgz"
             }
           },
           "values": "b25QcmVtRG9tYWluOiAidGVzdC5jYXJ0by5sb2NhbCIKCmltcG9ydFdvcmtlcjoKICBjb21tYW5kOgogICAgLSBzaAogICAgLSAtYwogICAgLSBzbGVlcCBpbmZpbml0eQoKd29ya3NwYWNlU3Vic2NyaWJlcjoKICBjb21tYW5kOgogICAgLSBzaAogICAgLSAtYwogICAgLSBzbGVlcCBpbmZpbml0eQo="
@@ -46,7 +45,7 @@
             },
             "config": {
               "remote": {
-                "workload": "deploy-accounts-www"
+                "workload": "deploy-carto-accounts-www"
               }
             }
           }

--- a/chart/tests/carto.yaml
+++ b/chart/tests/carto.yaml
@@ -9,6 +9,9 @@
       },
       "actions": [
         {
+          "action_id": "helm-package"
+        },
+        {
           "action_id": "linter-packaging",
           "params": {
             "kind": "HELM"
@@ -30,8 +33,8 @@
               "url": "https://github.com/CartoDB/carto3-helm/releases/download/v0.0.4/carto-0.0.4.tgz"
             }
           },
-          "values": "b25QcmVtRG9tYWluOiAidGVzdC5jYXJ0by5sb2NhbCIKCmltcG9ydFdvcmtlcjoKICBjb21tYW5kOgogICAgLSBzaAogICAgLSAtYwogICAgLSBzbGVlcCBpbmZpbml0eQoKd29ya3NwYWNlU3Vic2NyaWJlcjoKICBjb21tYW5kOgogICAgLSBzaAogICAgLSAtYwogICAgLSBzbGVlcCBpbmZpbml0eQo="
         },
+        "runtime_parameters": "b25QcmVtRG9tYWluOiAidGVzdC5jYXJ0by5sb2NhbCIKCmltcG9ydFdvcmtlcjoKICBjb21tYW5kOgogICAgLSBzaAogICAgLSAtYwogICAgLSBzbGVlcCBpbmZpbml0eQoKd29ya3NwYWNlU3Vic2NyaWJlcjoKICBjb21tYW5kOgogICAgLSBzaAogICAgLSAtYwogICAgLSBzbGVlcCBpbmZpbml0eQo=",
         "target_platform": {
           "target_platform_id": "91d398a2-25c4-4cda-8732-75a3cfc179a1"
         }

--- a/chart/tests/carto.yaml
+++ b/chart/tests/carto.yaml
@@ -23,7 +23,7 @@
       "context": {
         "resources": {
           "url": "https://github.com/CartoDB/carto3-helm/archive/refs/tags/v0.0.4.tar.gz",
-          "path": "chart/tests"
+          "path": "/chart/tests"
         },
         "runtime_parameters": "b25QcmVtRG9tYWluOiAidGVzdC5jYXJ0by5sb2NhbCIKCmltcG9ydFdvcmtlcjoKICBjb21tYW5kOgogICAgLSBzaAogICAgLSAtYwogICAgLSBzbGVlcCBpbmZpbml0eQoKd29ya3NwYWNlU3Vic2NyaWJlcjoKICBjb21tYW5kOgogICAgLSBzaAogICAgLSAtYwogICAgLSBzbGVlcCBpbmZpbml0eQo=",
         "target_platform": {

--- a/chart/tests/chart-values.yaml
+++ b/chart/tests/chart-values.yaml
@@ -1,0 +1,13 @@
+onPremDomain: "test.carto.local"
+
+importWorker:
+  command:
+    - sh
+    - -c
+    - sleep infinity
+
+workspaceSubscriber:
+  command:
+    - sh
+    - -c
+    - sleep infinity

--- a/chart/tests/goss/goss-accounts-www/goss.yaml
+++ b/chart/tests/goss/goss-accounts-www/goss.yaml
@@ -1,0 +1,20 @@
+file:
+  /etc/nginx/nginx.conf:
+    exists: true
+    mode: "0644"
+    size: 648
+    owner: root
+    group: root
+    filetype: file
+    contains: []
+  /usr/sbin/nginx:
+    exists: true
+    mode: "0755"
+    size: 1193768
+    owner: root
+    group: root
+    filetype: file
+    contains: []
+port:
+    tcp:80:
+      listening: true


### PR DESCRIPTION
**Description of the change**

First goss tests for 'accounts-www' pods

**Benefits**

Now it is possible to detect regressions that could affect to 'accounts-www' component. Also there is a dir structure that will keep goss tests separated per Carto's component.