### PR TITLE
feat!: :arrow_up: Bump PostgreSQL and Redis subchart major version

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.10.3
+  version: 1.11.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.13.14
+  version: 11.0.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 15.6.7
-digest: sha256:9d45ca630c1b5ca90dd787de388e5f1bb84c713f93dc4c14612ff14734c78793
-generated: "2021-12-22T17:24:11.907051+01:00"
+  version: 16.3.1
+digest: sha256:e7eb6bf26e10c5a32ae13b4d4c2c127a3505429353963c60e66df90f32c5dc56
+generated: "2022-02-08T15:48:46.348058+01:00"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -9,11 +9,11 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 10.x.x
+    version: 11.x.x
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 15.x.x
+    version: 16.x.x
 description: CARTO is the world's leading Location Intelligence platform, enabling organizations to use spatial data and analysis for more efficient delivery routes, better behavioural marketing, strategic store placements, and much more.
 engine: gotpl
 home: https://github.com/cartodb/carto3-helm/tree/stable/chart
@@ -25,4 +25,4 @@ keywords:
 name: carto
 sources:
   - https://carto.com/
-version: 0.0.4
+version: 1.0.0

--- a/chart/README.md
+++ b/chart/README.md
@@ -909,16 +909,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### PostgreSQL subchart parameters
 
-| Name                                    | Description                                                                               | Value                  |
-| --------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------- |
-| `postgresql.enabled`                    | Switch to enable or disable the PostgreSQL helm chart                                     | `true`                 |
-| `postgresql.postgresqlUsername`         | CARTO Postgresql username                                                                 | `carto`                |
-| `postgresql.postgresqlPassword`         | CARTO Postgresql password                                                                 | `""`                   |
-| `postgresql.postgresqlPostgresPassword` | CARTO Postgresql password for the postgres user                                           | `""`                   |
-| `postgresql.postgresqlDatabase`         | CARTO Postgresql database                                                                 | `workspace_db`         |
-| `postgresql.existingSecret`             | Name of an existing secret containing the PostgreSQL password ('postgresql-password' key) | `""`                   |
-| `postgresql.image.tag`                  | Tag of the PostgreSQL image                                                               | `12.9.0-debian-10-r39` |
-| `postgresql.initdbScripts`              | Scripts for initializing the database                                                     | `[]`                   |
+| Name                                | Description                                                                               | Value                  |
+| ----------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------- |
+| `postgresql.enabled`                | Switch to enable or disable the PostgreSQL helm chart                                     | `true`                 |
+| `postgresql.auth.username`          | CARTO Postgresql username                                                                 | `carto`                |
+| `postgresql.auth.password`          | CARTO Postgresql password                                                                 | `""`                   |
+| `postgresql.auth.postgresPassword`  | CARTO Postgresql password for the postgres user                                           | `""`                   |
+| `postgresql.auth.database`          | CARTO Postgresql database                                                                 | `workspace_db`         |
+| `postgresql.auth.existingSecret`    | Name of an existing secret containing the PostgreSQL password ('postgresql-password' key) | `""`                   |
+| `postgresql.image.tag`              | Tag of the PostgreSQL image                                                               | `13.5.0-debian-10-r84` |
+| `postgresql.primary.initdb.scripts` | Scripts for initializing the database                                                     | `[]`                   |
 
 
 ### External PostgreSQL parameters

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -73,18 +73,12 @@ host. To configure CARTO with the URL of your service:
 
   export CARTO_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "carto.router.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
 {{- end }}
-  {{ include "common.utils.secret.getvalue" (dict "secret" $postgresqlSecretName "field" "postgresql-password" "context" $) }}
-  {{ include "common.utils.secret.getvalue" (dict "secret" $postgresqlSecretName "field" "postgresql-postgres-password" "context" $) }}
-  {{ include "common.utils.secret.getvalue" (dict "secret" $redisSecretName "field" "redis-password" "context" $) }}
 
 2. Complete your CARTO deployment by running:
 
   helm upgrade --namespace {{ .Release.Namespace }} {{ .Release.Name }} carto/{{ .Chart.Name }} \
     --set router.service.type={{ .Values.router.service.type }} \
-    --set onPremDomain=$CARTO_HOST{{- if eq .Values.router.service.type "NodePort" }}:$CARTO_PORT{{- end }} \
-    --set postgresql.postgresqlPassword=$POSTGRESQL_PASSWORD \
-    --set postgresql.postgresqlPostgresPassword=$POSTGRESQL_POSTGRES_PASSWORD \
-    --set redis.auth.password=$REDIS_PASSWORD
+    --set onPremDomain=$CARTO_HOST{{- if eq .Values.router.service.type "NodePort" }}:$CARTO_PORT{{- end }}
 
 {{- else }}
 
@@ -110,16 +104,4 @@ host. To configure CARTO with the URL of your service:
 {{- end  }}
 
 {{ include "carto.validateValues" . }}
-
-{{- $postgresqlSecretName := include "carto.postgresql.secretName" . -}}
-{{- $redisSecretName := include "carto.redis.secretName" . -}}
-{{- $passwordValidationErrors := list -}}
-
-{{- $postgresqlPasswordValidationErrors := include "common.validations.values.postgresql.passwords" (dict "secret" $postgresqlSecretName "subchart" true "context" $) -}}
-{{- $passwordValidationErrors = append $passwordValidationErrors $postgresqlPasswordValidationErrors -}}
-
-{{- $redisPasswordValidationErrors := include "common.validations.values.redis.passwords" (dict "secret" $redisSecretName "subchart" true "context" $) -}}
-{{- $passwordValidationErrors = append $passwordValidationErrors $redisPasswordValidationErrors -}}
-
-{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}
 {{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -548,10 +548,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Get the Postgresql credentials secret.
 */}}
 {{- define "carto.postgresql.secretName" -}}
-{{- if and (.Values.postgresql.enabled) (not .Values.postgresql.existingSecret) -}}
+{{- if and (.Values.postgresql.enabled) (not .Values.postgresql.auth.existingSecret) -}}
     {{- printf "%s" (include "carto.postgresql.fullname" .) -}}
-{{- else if and (.Values.postgresql.enabled) (.Values.postgresql.existingSecret) -}}
-    {{- printf "%s" .Values.postgresql.existingSecret -}}
+{{- else if and (.Values.postgresql.enabled) (.Values.postgresql.auth.existingSecret) -}}
+    {{- printf "%s" .Values.postgresql.auth.existingSecret -}}
 {{- else }}
     {{- if .Values.externalDatabase.existingSecret -}}
         {{- printf "%s" .Values.externalDatabase.existingSecret -}}
@@ -572,7 +572,7 @@ Add environment variables to configure database values
 Add environment variables to configure database values
 */}}
 {{- define "carto.postgresql.user" -}}
-{{- ternary .Values.postgresql.postgresqlUsername .Values.externalDatabase.user .Values.postgresql.enabled | quote -}}
+{{- ternary .Values.postgresql.auth.username .Values.externalDatabase.user .Values.postgresql.enabled | quote -}}
 {{- end -}}
 
 {{/*
@@ -586,7 +586,7 @@ Add environment variables to configure database values
 Add environment variables to configure database values
 */}}
 {{- define "carto.postgresql.databaseName" -}}
-{{- ternary .Values.postgresql.postgresqlDatabase .Values.externalDatabase.database .Values.postgresql.enabled | quote -}}
+{{- ternary .Values.postgresql.auth.database .Values.externalDatabase.database .Values.postgresql.enabled | quote -}}
 {{- end -}}
 
 {{/*
@@ -594,7 +594,7 @@ Add environment variables to configure database values
 */}}
 {{- define "carto.postgresql.secret.key" -}}
 {{- if .Values.postgresql.enabled -}}
-    {{- printf "%s" "postgresql-password" -}}
+    {{- printf "%s" "password" -}}
 {{- else -}}
     {{- if .Values.externalDatabase.existingSecret -}}
         {{- if .Values.externalDatabase.existingSecretPasswordKey -}}
@@ -613,16 +613,16 @@ Add environment variables to configure database values
 */}}
 {{- define "carto.postgresql.secret.adminKey" -}}
 {{- if .Values.postgresql.enabled -}}
-    {{- printf "%s" "postgresql-postgres-password" -}}
+    {{- print "postgres-password" -}}
 {{- else -}}
     {{- if .Values.externalDatabase.existingSecret -}}
         {{- if .Values.externalDatabase.existingSecretAdminPasswordKey -}}
             {{- printf "%s" .Values.externalDatabase.existingSecretAdminPasswordKey -}}
         {{- else -}}
-            {{- printf "%s" "db-admin-password" -}}
+            {{- print "db-admin-password" -}}
         {{- end -}}
     {{- else -}}
-        {{- printf "%s" "db-admin-password" -}}
+        {{- print "db-admin-password" -}}
     {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -733,16 +733,16 @@ Add environment variables to configure Redis values
 */}}
 {{- define "carto.redis.existingsecret.key" -}}
 {{- if .Values.redis.enabled -}}
-    {{- printf "%s" "redis-password" -}}
+    {{- print "redis-password" -}}
 {{- else -}}
     {{- if .Values.externalRedis.existingSecret -}}
         {{- if .Values.externalRedis.existingSecretPasswordKey -}}
             {{- printf "%s" .Values.externalRedis.existingSecretPasswordKey -}}
         {{- else -}}
-            {{- printf "%s" "redis-password" -}}
+            {{- print "redis-password" -}}
         {{- end -}}
     {{- else -}}
-        {{- printf "%s" "redis-password" -}}
+        {{- print "redis-password" -}}
     {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/chart/templates/import-api/deployment.yaml
+++ b/chart/templates/import-api/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "carto.postgresql.secretName" . }}
-                  key: {{ ternary "postgresql-password" "db-password" .Values.postgresql.enabled | quote }}
+                  key: {{ ternary "password" "db-password" .Values.postgresql.enabled | quote }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2865,36 +2865,39 @@ externalRedis:
 ## PostgreSQL chart configuration
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
 ## @param postgresql.enabled Switch to enable or disable the PostgreSQL helm chart
-## @param postgresql.postgresqlUsername CARTO Postgresql username
-## @param postgresql.postgresqlPassword CARTO Postgresql password
-## @param postgresql.postgresqlPostgresPassword CARTO Postgresql password for the postgres user
-## @param postgresql.postgresqlDatabase CARTO Postgresql database
-## @param postgresql.existingSecret Name of an existing secret containing the PostgreSQL password ('postgresql-password' key)
+## @param postgresql.auth.username CARTO Postgresql username
+## @param postgresql.auth.password CARTO Postgresql password
+## @param postgresql.auth.postgresPassword CARTO Postgresql password for the postgres user
+## @param postgresql.auth.database CARTO Postgresql database
+## @param postgresql.auth.existingSecret Name of an existing secret containing the PostgreSQL password ('postgresql-password' key)
 ##
 postgresql:
   enabled: true
   ## @param postgresql.image.tag Tag of the PostgreSQL image
   ##
   image:
-    tag: "12.9.0-debian-10-r39"
-  postgresqlUsername: carto
-  postgresqlPassword: ""
-  postgresqlDatabase: workspace_db
-  postgresqlPostgresPassword: ""
-  ## This secret is used in case of postgresql.enabled=true and we would like to specify password for newly created postgresql instance
+    tag: "13.5.0-debian-10-r84"
+  auth:
+    username: carto
+    password: ""
+    database: workspace_db
+    postgresPassword: ""
+    ## This secret is used in case of postgresql.enabled=true and we would like to specify password for newly created postgresql instance
+    ##
+    existingSecret: ""
+  ## @param postgresql.primary.initdb.scripts [array] Scripts for initializing the database
   ##
-  existingSecret: ""
-  ## @param postgresql.initdbScripts [array] Scripts for initializing the database
-  ##
-  initdbScripts:
-    # HACK: Temporary workaround until we propose the CARTO team to change the workspace-migrations logic so it accepts an already existing database
-    delete_db_and_user.sh: |
-      # Using bash because we need the postgres user and the initDbUser and initDbPassword values don't work
-      # correctly with the postgres user
-      PGPASSWORD=$POSTGRES_POSTGRES_PASSWORD psql -U postgres <<EOF
-      DROP DATABASE "{{ .Values.postgresqlDatabase }}";
-      DROP USER "{{ .Values.postgresqlUsername }}";
-      EOF
+  primary:
+    initdb:
+      scripts:
+        # HACK: Temporary workaround until we propose the CARTO team to change the workspace-migrations logic so it accepts an already existing database
+        delete_db_and_user.sh: |
+          # Using bash because we need the postgres user and the initDbUser and initDbPassword values don't work
+          # correctly with the postgres user
+          PGPASSWORD=$POSTGRES_POSTGRES_PASSWORD psql -U postgres <<EOF
+          DROP DATABASE "{{ .Values.auth.database }}";
+          DROP USER "{{ .Values.auth.username }}";
+          EOF
 ## @section External PostgreSQL parameters
 ## External PostgreSQL configuration
 ## All of these values are only used when postgresql.enabled is set to false


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

BREAKING CHANGE: This PR bumps the PostgreSQL subchart to 11.x.x and Redis to 16.x.x. It also changes the PostgreSQL container version to branch 13. The values have been adapted and unnecessary checks have been removed.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

New features

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

Users will need to adapt their values.yaml file in case they were using the Redis and PostgreSQL subcharts. They will also need to change the PostgreSQL version.

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->